### PR TITLE
Feature Implement Signals/Slots

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -11,5 +11,12 @@
 	"sourcePaths": ["source"],
 	"importPaths": [
 		"source"
-	]
+	],
+	"buildTypes": {
+		"unittest-dip1000": {
+			"buildOptions": ["unittests", "debugMode"],
+			"dflags": ["-preview=dip1000"],
+			"versions": ["vsignal_dip1000"]
+		}
+	}
 }

--- a/source/vsignal/signal.d
+++ b/source/vsignal/signal.d
@@ -26,6 +26,50 @@ package:
 	Slot!F[] calls;
 }
 
+///
+unittest
+{
+	Signal!(void delegate(int) @safe pure nothrow) signal;
+	Signal!(void delegate(ref int) @safe pure nothrow) signalRef;
+
+	static struct Listener
+	{
+		int i;
+		void opCall()(const ref int)
+		{
+			i++;
+		}
+	}
+
+	Listener listener;
+
+	signal.sink.connect!(Listener.opCall)(listener);
+	signalRef.sink.connect!(Listener.opCall)(listener);
+
+	int var;
+
+	signal.emit(var);
+	signalRef.emit(var);
+
+	assert(listener.i == 2);
+}
+
+///
+unittest
+{
+	Signal!(void delegate(int)) signal;
+	int var = 35;
+
+	signal.sink.connect!((ref i, const int x) {
+		assert(&i is &var);
+		i += x;
+	})(var);
+
+	signal.emit(3);
+
+	assert(var == 38);
+}
+
 unittest
 {
 	Signal!(void delegate(int)) sig;

--- a/source/vsignal/signal.d
+++ b/source/vsignal/signal.d
@@ -1,5 +1,6 @@
 module vsignal.signal;
 
+import vsignal.sink;
 import vsignal.slot;
 
 struct Signal(F)

--- a/source/vsignal/signal.d
+++ b/source/vsignal/signal.d
@@ -1,0 +1,7 @@
+module vsignal.signal;
+
+struct Signal(F)
+	if (is(F : RT delegate(Args), RT, Args...))
+{
+
+}

--- a/source/vsignal/signal.d
+++ b/source/vsignal/signal.d
@@ -14,6 +14,14 @@ struct Signal(F)
 			cast(void) call(forward!args);
 	}
 
+	Sink!F sink(this This)()
+	{
+		// https://issues.dlang.org/show_bug.cgi?id=22309
+		auto sinkImpl = (ref return This signal) => Sink!F(&signal);
+
+		return sinkImpl(this);
+	}
+
 package:
 	Slot!F[] calls;
 }

--- a/source/vsignal/signal.d
+++ b/source/vsignal/signal.d
@@ -27,6 +27,11 @@ struct Signal(F)
 		return !calls.length;
 	}
 
+	size_t length() const @property
+	{
+		return calls.length;
+	}
+
 package:
 	Slot!F[] calls;
 }

--- a/source/vsignal/signal.d
+++ b/source/vsignal/signal.d
@@ -16,3 +16,30 @@ struct Signal(F)
 package:
 	Slot!F[] calls;
 }
+
+unittest
+{
+	Signal!(void delegate(int)) sig;
+
+	struct Listener
+	{
+		int i;
+		void opCall(int var) { i = var; }
+	}
+
+	Listener listener;
+
+	Slot!(void delegate(int)) slotA;
+	Slot!(void delegate(int)) slotB;
+
+	slotA.connect!(Listener.opCall)(listener);
+	slotB.connect!((ref i) => listener.i++ );
+
+	sig.calls = [
+		slotA,
+		slotB
+	];
+
+	sig.emit(5);
+	assert(listener.i == 6);
+}

--- a/source/vsignal/signal.d
+++ b/source/vsignal/signal.d
@@ -6,6 +6,12 @@ import vsignal.slot;
 struct Signal(F)
 	if (is(F : RT delegate(Args), RT, Args...))
 {
+	/**
+	Publish a signal.
+
+	Params:
+		args = the Signal's function parameters to call each listener with.
+	*/
 	void emit(Slot!F.Parameters args)
 	{
 		import core.lifetime : forward;

--- a/source/vsignal/signal.d
+++ b/source/vsignal/signal.d
@@ -1,5 +1,7 @@
 module vsignal.signal;
 
+import vsignal.slot;
+
 struct Signal(F)
 	if (is(F : RT delegate(Args), RT, Args...))
 {

--- a/source/vsignal/signal.d
+++ b/source/vsignal/signal.d
@@ -5,6 +5,13 @@ import vsignal.slot;
 struct Signal(F)
 	if (is(F : RT delegate(Args), RT, Args...))
 {
+	void emit(Slot!F.Parameters args)
+	{
+		import core.lifetime : forward;
+
+		foreach (call; calls)
+			cast(void) call(forward!args);
+	}
 
 package:
 	Slot!F[] calls;

--- a/source/vsignal/signal.d
+++ b/source/vsignal/signal.d
@@ -22,6 +22,11 @@ struct Signal(F)
 		return sinkImpl(this);
 	}
 
+	bool empty() const @property
+	{
+		return !calls.length;
+	}
+
 package:
 	Slot!F[] calls;
 }

--- a/source/vsignal/signal.d
+++ b/source/vsignal/signal.d
@@ -20,6 +20,16 @@ struct Signal(F)
 			cast(void) call(forward!args);
 	}
 
+	/**
+	Get a Sink to connect and disconnect listeners from a Signal.
+
+	This function can be @trusted if the lifetime of the Sink does not extend the
+	lifetime of the Signal.
+
+	Note: DIP1000 can detect if a reference escapes and as such it can infer @safe.
+
+	Returns: A newly constructed Sink.
+	*/
 	Sink!F sink(this This)()
 	{
 		// https://issues.dlang.org/show_bug.cgi?id=22309

--- a/source/vsignal/signal.d
+++ b/source/vsignal/signal.d
@@ -6,4 +6,6 @@ struct Signal(F)
 	if (is(F : RT delegate(Args), RT, Args...))
 {
 
+package:
+	Slot!F[] calls;
 }

--- a/source/vsignal/signal.d
+++ b/source/vsignal/signal.d
@@ -100,6 +100,18 @@ unittest
 {
 	Signal!(void delegate(int)) sig;
 
+	version(vsignal_dip1000)
+		static assert( __traits(compiles, () @safe { sig.sink; } )); // calling Sink is @safe
+	else
+		static assert(!__traits(compiles, () @safe { sig.sink; } )); // calling Sink is @system
+
+	static assert(!__traits(compiles, () @safe => Signal!(void delegate(int)).sink));
+}
+
+unittest
+{
+	Signal!(void delegate(int)) sig;
+
 	struct Listener
 	{
 		int i;

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -131,11 +131,21 @@ void disconnect(F)(auto ref Sink!F sink)
 	sinksignal.calls = [];
 }
 
+/**
+Used as a bridge between Sink and Connection to correctly disconnect a listener
+from a signal.
+
+Params:
+	pred = the listener to disconnect,
+	signal = the signal that contains the listener.
+	instance = the payload that is attached to the listener.
+*/
 private void release(alias pred, F)(void* signal)
 {
 	Sink!F(() @trusted { return cast(Signal!F*) signal; } ()).disconnect!pred();
 }
 
+///
 private void release(alias pred, T, F)(ref T instance, void* signal)
 {
 	Sink!F(() @trusted { return cast(Signal!F*) signal; } ()).disconnect!pred(instance);

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -37,6 +37,11 @@ void disconnect(alias pred, T, F)(auto ref Sink!F sink, ref T instance)
 	}
 }
 
+private void release(alias pred, F)(void* signal)
+{
+	Sink!F(() @trusted { return cast(Signal!F*) signal; } ()).disconnect!pred();
+}
+
 struct Sink(F)
 {
 private:

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -3,6 +3,23 @@ module vsignal.sink;
 import vsignal.signal;
 import vsignal.slot : Slot, slot_connect = connect;
 
+void disconnect(alias pred, F)(auto ref Sink!F sink)
+{
+	import std.algorithm.mutation : remove, SwapStrategy;
+	import std.algorithm.searching : countUntil;
+
+	Slot!F call;
+	call.slot_connect!pred;
+
+	with (sink)
+	{
+		const index = signal.calls.countUntil(call);
+
+		if (index > -1)
+			signal.calls = signal.calls.remove!(SwapStrategy.unstable)(index);
+	}
+}
+
 struct Sink(F)
 {
 private:

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -75,6 +75,16 @@ void disconnect(alias pred, T, F)(auto ref Sink!F sink, ref T instance)
 	}
 }
 
+void disconnect(T, F)(auto ref Sink!F sink, ref T instance)
+{
+	import std.algorithm.mutation : remove, SwapStrategy;
+
+	with (sink)
+	{
+		signal.calls = signal.calls.remove!(call => call.payload is &instance , SwapStrategy.unstable);
+	}
+}
+
 private void release(alias pred, F)(void* signal)
 {
 	Sink!F(() @trusted { return cast(Signal!F*) signal; } ()).disconnect!pred();

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -1,6 +1,7 @@
 module vsignal.sink;
 
 import vsignal.signal;
+import vsignal.slot : Slot, slot_connect = connect;
 
 struct Sink(F)
 {

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -112,6 +112,11 @@ struct Sink(F)
 		return signal.length;
 	}
 
+	bool empty() const @property
+	{
+		return signal.empty;
+	}
+
 private:
 	Signal!F* signal;
 }

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -85,6 +85,11 @@ void disconnect(T, F)(auto ref Sink!F sink, ref T instance)
 	}
 }
 
+void disconnect(F)(auto ref Sink!F sink)
+{
+	sinksignal.calls = [];
+}
+
 private void release(alias pred, F)(void* signal)
 {
 	Sink!F(() @trusted { return cast(Signal!F*) signal; } ()).disconnect!pred();

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -1,0 +1,9 @@
+module vsignal.sink;
+
+import vsignal.signal;
+
+struct Sink(F)
+{
+private:
+	Signal!F* signal;
+}

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -123,6 +123,11 @@ private:
 
 struct Connection
 {
+	bool opCast(T : bool)() const
+	{
+		return disconnect;
+	}
+
 	void release()()
 	{
 		if (disconnect)

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -3,6 +3,19 @@ module vsignal.sink;
 import vsignal.signal;
 import vsignal.slot : Slot, slot_connect = connect;
 
+/**
+Connect a listener to a Signal.
+
+A payload can be passed if the function to call is a data member function of the
+same or if the function accepts as its first parameter a reference to its type.
+
+Params:
+	pred = the listener to connect.
+	sink = the Sink that holds the signal.
+	instance = the payload to store.
+
+Returns: A Connection of the listener.
+*/
 Connection connect(alias pred, F)(auto ref Sink!F sink)
 {
 	sink.disconnect!pred;
@@ -22,6 +35,7 @@ Connection connect(alias pred, F)(auto ref Sink!F sink)
 	}
 }
 
+///
 Connection connect(alias pred, T, F)(auto ref Sink!F sink, ref T instance)
 {
 	sink.disconnect!pred(instance);

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -55,6 +55,30 @@ Connection connect(alias pred, T, F)(auto ref Sink!F sink, ref T instance)
 	}
 }
 
+/++
+Disconnects a listener from a Signal. The order is not preserved after the
+removal.
+
+Examples:
+---
+void method() {}
+struct Foo { void method() {} }
+Foo foo;
+
+/* ... */
+
+// lets assume a signal exists with listeners
+sink.disconnect!(Foo.method)(foo); // disconnects Foo.method with payload foo
+sink.disconnect!method;            // disconnects method
+sink.disconnect(foo);              // disconnects all listeners with payload foo
+sink.disconnect();                 // disconnects all listeners
+---
+
+Params:
+	pred = the listener to disconnect.
+	sink = the Sink that holds the signal.
+	instance = the payload that composes the listener.
++/
 void disconnect(alias pred, F)(auto ref Sink!F sink)
 {
 	import std.algorithm.mutation : remove, SwapStrategy;
@@ -72,6 +96,7 @@ void disconnect(alias pred, F)(auto ref Sink!F sink)
 	}
 }
 
+///
 void disconnect(alias pred, T, F)(auto ref Sink!F sink, ref T instance)
 {
 	import std.algorithm.mutation : remove, SwapStrategy;
@@ -89,6 +114,7 @@ void disconnect(alias pred, T, F)(auto ref Sink!F sink, ref T instance)
 	}
 }
 
+///
 void disconnect(T, F)(auto ref Sink!F sink, ref T instance)
 {
 	import std.algorithm.mutation : remove, SwapStrategy;
@@ -99,6 +125,7 @@ void disconnect(T, F)(auto ref Sink!F sink, ref T instance)
 	}
 }
 
+///
 void disconnect(F)(auto ref Sink!F sink)
 {
 	sinksignal.calls = [];

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -102,6 +102,11 @@ private void release(alias pred, T, F)(ref T instance, void* signal)
 
 struct Sink(F)
 {
+	this(scope Signal!F* sig)
+	{
+		signal = sig;
+	}
+
 private:
 	Signal!F* signal;
 }

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -107,6 +107,11 @@ struct Sink(F)
 		signal = sig;
 	}
 
+	size_t length() const @property
+	{
+		return signal.length;
+	}
+
 private:
 	Signal!F* signal;
 }

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -3,6 +3,7 @@ module vsignal.sink;
 import vsignal.signal;
 import vsignal.slot : Slot, slot_connect = connect;
 
+// https://issues.dlang.org/show_bug.cgi?id=5710
 /**
 Connect a listener to a Signal.
 
@@ -55,6 +56,7 @@ Connection connect(alias pred, T, F)(auto ref Sink!F sink, ref T instance)
 	}
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=5710
 /++
 Disconnects a listener from a Signal. The order is not preserved after the
 removal.
@@ -131,6 +133,7 @@ void disconnect(F)(auto ref Sink!F sink)
 	sinksignal.calls = [];
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=5710
 /**
 Used as a bridge between Sink and Connection to correctly disconnect a listener
 from a signal.

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -42,6 +42,11 @@ private void release(alias pred, F)(void* signal)
 	Sink!F(() @trusted { return cast(Signal!F*) signal; } ()).disconnect!pred();
 }
 
+private void release(alias pred, T, F)(ref T instance, void* signal)
+{
+	Sink!F(() @trusted { return cast(Signal!F*) signal; } ()).disconnect!pred(instance);
+}
+
 struct Sink(F)
 {
 private:

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -7,3 +7,10 @@ struct Sink(F)
 private:
 	Signal!F* signal;
 }
+
+struct Connection
+{
+private:
+	Slot!(void delegate(void*) @safe pure nothrow) disconnect;
+	void* signal;
+}

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -20,6 +20,23 @@ void disconnect(alias pred, F)(auto ref Sink!F sink)
 	}
 }
 
+void disconnect(alias pred, T, F)(auto ref Sink!F sink, ref T instance)
+{
+	import std.algorithm.mutation : remove, SwapStrategy;
+	import std.algorithm.searching : countUntil;
+
+	Slot!F call;
+	call.slot_connect!pred(instance);
+
+	with (sink)
+	{
+		const index = signal.calls.countUntil(call);
+
+		if (index > -1)
+			signal.calls = signal.calls.remove!(SwapStrategy.unstable)(index);
+	}
+}
+
 struct Sink(F)
 {
 private:

--- a/source/vsignal/sink.d
+++ b/source/vsignal/sink.d
@@ -10,6 +10,15 @@ private:
 
 struct Connection
 {
+	void release()()
+	{
+		if (disconnect)
+		{
+			disconnect(signal);
+			disconnect.reset();
+		}
+	}
+
 private:
 	Slot!(void delegate(void*) @safe pure nothrow) disconnect;
 	void* signal;

--- a/source/vsignal/slot.d
+++ b/source/vsignal/slot.d
@@ -16,6 +16,30 @@ package void connect(alias pred, F)(auto ref Slot!F slot)
 	}
 }
 
+@safe pure nothrow @nogc unittest
+{
+	Slot!(void delegate(int)) slot;
+
+	class C
+	{
+		static void opCall(int) {}
+		static void fooA(const int) {}
+		static void fooB(ref int) {}
+		static void fooC(const ref int) {}
+	}
+
+	// all lambda listeners can omit the type
+	slot.connect!((ref _)       {});
+	slot.connect!((const ref _) {});
+	slot.connect!((_)           {});
+	slot.connect!((const _)     {});
+
+	slot.connect!(C.opCall);
+	slot.connect!(C.fooA);
+	slot.connect!(C.fooB);
+	slot.connect!(C.fooC);
+}
+
 package struct Slot(F)
 {
 	import vsignal.utils : from;

--- a/source/vsignal/slot.d
+++ b/source/vsignal/slot.d
@@ -1,5 +1,6 @@
 module vsignal.slot;
 
+// https://issues.dlang.org/show_bug.cgi?id=5710
 /**
 Binds a function to a Slot. A payload can be passed if the function to call is
 a data member function of the same or if the function accepts as its first

--- a/source/vsignal/slot.d
+++ b/source/vsignal/slot.d
@@ -1,0 +1,24 @@
+module vsignal.slot;
+
+package struct Slot(F)
+{
+	import vsignal.utils : from;
+
+	alias SlotType = F;
+	alias ReturnType = from!"std.traits".ReturnType!F;
+	alias Parameters = from!"std.traits".Parameters!F;
+	alias Function   = from!"std.traits".SetFunctionAttributes!(
+		ReturnType delegate(const scope void*, Parameters),
+		from!"std.traits".functionLinkage!SlotType,
+		from!"std.traits".functionAttributes!SlotType
+	);
+
+	auto opCall(Parameters args)
+	{
+		return fn(payload, from!"core.lifetime".forward!args);
+	}
+
+package:
+	Function fn;
+	void* payload;
+}

--- a/source/vsignal/slot.d
+++ b/source/vsignal/slot.d
@@ -109,6 +109,11 @@ package struct Slot(F)
 		payload = null;
 	}
 
+	bool opCast(T : bool)() const
+	{
+		return fn.funcptr !is null;
+	}
+
 package:
 	Function fn;
 	void* payload;

--- a/source/vsignal/slot.d
+++ b/source/vsignal/slot.d
@@ -60,6 +60,26 @@ package void connect(alias pred, T, F)(auto ref Slot!F slot, ref T instance)
 	}
 }
 
+@safe pure nothrow @nogc unittest
+{
+	Slot!(void delegate(int)) slot;
+
+	struct Listener
+	{
+		void opCall(int) {}
+		void fooA(const int) {}
+		void fooB(ref int) {}
+		void fooC(const ref int) {}
+	}
+
+	Listener listener;
+
+	slot.connect!(Listener.opCall)(listener);
+	slot.connect!(Listener.fooA)(listener);
+	slot.connect!(Listener.fooB)(listener);
+	slot.connect!(Listener.fooC)(listener);
+}
+
 package struct Slot(F)
 {
 	import vsignal.utils : from;

--- a/source/vsignal/slot.d
+++ b/source/vsignal/slot.d
@@ -1,5 +1,21 @@
 module vsignal.slot;
 
+package void connect(alias pred, F)(auto ref Slot!F slot)
+{
+	import vsignal.utils : tryForward;
+
+	with(slot)
+	{
+		payload = null;
+		fn = (const scope void*, Parameters args) {
+			static if (is(ReturnType == void))
+				pred(tryForward!(pred, args));
+			else
+				return ReturnType(pred(tryForward!(pred, args)));
+		};
+	}
+}
+
 package struct Slot(F)
 {
 	import vsignal.utils : from;

--- a/source/vsignal/slot.d
+++ b/source/vsignal/slot.d
@@ -1,5 +1,15 @@
 module vsignal.slot;
 
+/**
+Binds a function to a Slot. A payload can be passed if the function to call is
+a data member function of the same or if the function accepts as its first
+parameter a reference to its type.
+
+Params:
+	pred = the function to bind.
+	slot = the Slot that holds the function.
+	instance = the payload to keep.
+*/
 package void connect(alias pred, F)(auto ref Slot!F slot)
 {
 	import vsignal.utils : tryForward;
@@ -40,6 +50,7 @@ package void connect(alias pred, F)(auto ref Slot!F slot)
 	slot.connect!(C.fooC);
 }
 
+///
 package void connect(alias pred, T, F)(auto ref Slot!F slot, ref T instance)
 {
 	with(slot)

--- a/source/vsignal/slot.d
+++ b/source/vsignal/slot.d
@@ -98,6 +98,11 @@ package struct Slot(F)
 		return fn(payload, from!"core.lifetime".forward!args);
 	}
 
+	bool opEquals(F)(const Slot!F other) const
+	{
+		return fn.funcptr is other.fn.funcptr && payload is other.payload;
+	}
+
 package:
 	Function fn;
 	void* payload;

--- a/source/vsignal/slot.d
+++ b/source/vsignal/slot.d
@@ -103,6 +103,12 @@ package struct Slot(F)
 		return fn.funcptr is other.fn.funcptr && payload is other.payload;
 	}
 
+	void reset()
+	{
+		fn = null;
+		payload = null;
+	}
+
 package:
 	Function fn;
 	void* payload;

--- a/source/vsignal/slot.d
+++ b/source/vsignal/slot.d
@@ -102,3 +102,28 @@ package:
 	Function fn;
 	void* payload;
 }
+
+///
+unittest
+{
+	@safe struct Listener
+	{
+		int i;
+
+		auto foo(int var) return
+		{
+			i = var;
+			return &this;
+		}
+	}
+
+	Listener listener;
+	alias myfoo = Listener.foo;
+
+	Slot!(Listener* delegate(int) @safe) slot;
+
+	slot.connect!(myfoo)(listener);
+
+	assert(slot(4) is &listener);
+	assert(listener.i == 4);
+}

--- a/source/vsignal/utils.d
+++ b/source/vsignal/utils.d
@@ -1,5 +1,15 @@
 module vsignal.utils;
 
+/**
+Attempts to forward each parameter. If a parameters cannot be forwarded to F
+then the same is treated as an 'lvalue' and copied.
+
+Params:
+	F = Function to follow.
+	args = a parameter list or an std.meta.AliasSeq.
+
+Returns: An `AliasSeq` of args ready to be correctly forwarded or copied.
+*/
 package template tryForward(alias F, args...)
 {
 	import core.lifetime : forward;

--- a/source/vsignal/utils.d
+++ b/source/vsignal/utils.d
@@ -33,3 +33,35 @@ package template tryForward(alias F, args...)
 
 	alias tryForward = tryForwardImpl!(0, args.length);
 }
+
+@safe pure nothrow @nogc unittest
+{
+	class C
+	{
+		static int foo(int) { return 1; }
+		static int foo(ref int) { return 2; }
+
+		static int foo(int, ref int) { return 1; }
+		static int foo(ref int, int) { return 2; }
+
+		static int foo(ref int, int, const int, const ref int) { return 2; }
+	}
+
+	int foo(Args...)(auto ref Args args)
+	{
+		return C.foo(tryForward!(C.foo, args));
+	}
+
+	int i;
+
+	assert(foo(4) == 1);
+	assert(foo(i) == 2);
+
+	assert(foo(4, i) == 1);
+	assert(foo(i, 4) == 2);
+
+	assert(foo(i, 4, i, 4) == 2);
+
+	static assert(!__traits(compiles, foo(i, i)));
+	static assert(!__traits(compiles, foo(4, 4)));
+}

--- a/source/vsignal/utils.d
+++ b/source/vsignal/utils.d
@@ -87,6 +87,33 @@ package template from(string mod)
 	mixin("import from = ", mod, ";");
 }
 
+/**
+Correctly calls a function with the given arguments.
+
+If `F` is not a Callable (e.g lambda infered as void) then `F` is called with
+`args`. If `F` is Callable and is a member function of `args[0]`, then the
+function is called using `args[0]` as the instance with `args[1..$]` as the
+parameters. Otherwise, `F` is called normally. The arguments are attempted to be
+forwarded with `tryForward`.
+
+Params:
+	F = the function to invoke.
+	args = the arguments to call F with.
+
+Examples:
+---
+void method(ref Foo) {}
+
+struct Foo { void method() {} }
+Foo foo;
+
+invoke!(Foo.method)(foo); // correctly invokes method from foo
+invoke!method(foo);       // correctly invokes method
+invoke!(_ => _ + 1)(4);   // correctly invokes the lambda
+---
+
+Returns: The value returned by `F`.
+*/
 package auto ref invoke(alias F, Args...)(auto ref Args args)
 	if (!from!"std.traits".isCallable!F)
 {
@@ -95,6 +122,7 @@ package auto ref invoke(alias F, Args...)(auto ref Args args)
 	return F(tryForward!(F, args));
 }
 
+///
 package auto ref invoke(alias F, Args...)(auto ref Args args)
 	if (from!"std.traits".isCallable!F)
 {

--- a/source/vsignal/utils.d
+++ b/source/vsignal/utils.d
@@ -1,0 +1,35 @@
+module vsignal.utils;
+
+package template tryForward(alias F, args...)
+{
+	import core.lifetime : forward;
+	import std.meta : AliasSeq;
+
+	// binary search forwardable params
+	template tryForwardImpl(size_t l, size_t r)
+	{
+		alias fwd = forward!(args[l..r]);
+
+		// Safe clause
+		static if (l == r)
+			alias tryForwardImpl = AliasSeq!();
+
+		// If it compiles then F(..., (l .. r), ...) can be forwarded
+		else static if (__traits(compiles, F(args[0..l], fwd, args[r..$])))
+			alias tryForwardImpl = fwd;
+
+		// If we're down to 2 elems just recurse each
+		else static if (r - l == 2)
+			alias tryForwardImpl = AliasSeq!(tryForwardImpl!(l, r - 1), tryForwardImpl!(r - 1, r));
+
+		// If it didn't compile and we have 1 elem left then treat as `lvalue`
+		else static if (r - l == 1)
+			alias tryForwardImpl = args[l..r];
+
+		// If all else fails divide in half
+		else
+			alias tryForwardImpl = AliasSeq!(tryForwardImpl!(l, r / 2), tryForwardImpl!(r / 2, r));
+	}
+
+	alias tryForward = tryForwardImpl!(0, args.length);
+}

--- a/source/vsignal/utils.d
+++ b/source/vsignal/utils.d
@@ -65,3 +65,8 @@ package template tryForward(alias F, args...)
 	static assert(!__traits(compiles, foo(i, i)));
 	static assert(!__traits(compiles, foo(4, 4)));
 }
+
+package template from(string mod)
+{
+	mixin("import from = ", mod, ";");
+}

--- a/source/vsignal/utils.d
+++ b/source/vsignal/utils.d
@@ -76,6 +76,12 @@ package template tryForward(alias F, args...)
 	static assert(!__traits(compiles, foo(4, 4)));
 }
 
+/**
+Helper for inline imports.
+
+Params:
+	mod = module to import.
+*/
 package template from(string mod)
 {
 	mixin("import from = ", mod, ";");


### PR DESCRIPTION
Signals/Slots implementation. This implementation is based on the pattern used in the lib [ENTT](https://github.com/skypjack/entt/wiki/Crash-Course:-events,-signals-and-everything-in-between#signals). 

The idea is simple: implement Signals in a way that is simple to use while offering versatility.

This implementation does not offer any kind of automatic disconnection. The user is responsible for guaranteeing that the **lifetime** of the listeners is **longer** than the **lifetime** of the signal. And as such, the user is also responsible for disconnecting the listeners.

---

A Signal is declared with a **delegate**:

```d
Signal!(void delegate(int)) sig;
```

To connect listeners a function pointer, lambda, or delegate can be passed:

```d
void foo(const int) {}

sig.sink.connect!((int) {});
sig.sink.connect!foo;
```

---

Forward is applied when possible. However, in D `forward` treats `lvalues` as `rvalues` to fix the ambiguity problem (see [here](https://druntime.dpldocs.info/core.lifetime.forward.html#examples)). To go around the situations when trying to `move` does not work, Signal fallsback to the normal execution for **that** variable and does a **copy**.

This can cause a slight bump in the execution speed when using a `Signal!(void delegate(int))` and connecting a `void delegate(ref int)` listener for example.

---

When connecting lambdas the parameters can be omitted:

```d
sig.sink.connect((_) {});
sig.sink.connect((const _) {});
sig.sink.connect((ref _) {});
sig.sink.connect((ref const _) {});
```

Signal also accepts connecting listeners from instances:

```d
struct Listener
{
	void opCall(const int) {}
}

Listener listener;

sig.sink.connect!(Listener.opCall)(listener);
```

---

As seen above, it is possible to attach an instance to a **Slot**. This also has some advantages for structuring the code internally. It also allows the user to specify a listener that receives a `ref`. Take a look at the following:

```d
void bar(immutable ref int, int) {}
immutable int var = 5;

sig.sink.connect!bar(var);
sig.emit(45);
```

As you can see, the **Signal** is still `void delegate(int)` however, the **Slot** that contains the listener `bar` also has attached the payload `var`, which will be passed to the function's first argument.

---

Listener connection must be executed with **Sink**. As seen throughout this explanation, all examples use `sink` before connecting a listener. This allows for **Signal** to be declared privately internally to omit `emit` functionality to the user. The user receives a **Sink** a works with it to `connect` and `disconnect` listeners. The **Sink** also returns another data structure to help managing listeners. The **Connection** structure is returned every time a connection is made. **Connection** allows the user to break a connection without having to rely on managing **Signal** or **Sink** instances.

---

## Signal usage example:

```d
void foo(immutable ref Listener, int) {}
void bar(int) {}

@safe struct Listener
{
	void opCall(const int) {}
}

void main() @safe
{
	Signal!(void delegate(int) @safe) sig;
	with (sink)
	{

		Listener listener;

		// connecting
		sink.connect!(Listener.opCall)(listener);
		sink.connect!foo(listener);
		sink.connect!bar;
		auto connection = sink.connect!((ref _) {});

		sig.emit(45);

		// disconnect a listener with an instance
		sink.disconnect!(Listener.opCall)(instance);

		// disconnect a listener
		sink.disconnect!bar;

		// disconnect all listeners with an instance
		sink.disconnect(listener);

		// disconnect all listeners
		sink.disconnect();

		// for lambdas the connection must be used
		connection.release();
	}
}
```

---

## Known Design issues

AFAIK D does not have a way to take field addresses. So when executing `Listener.opCall` what is happening is that only the `opCall` signature is being passed, discarding any connection to `Listener`. 

```d
void foo(ref Listener, int) { assert(false); }

struct Listener
{
	int i;
	void foo(int) { i++; }
}

Listener listener;

Signal!(void delegate(int)) sig;
sig.sink.connect!foo(listener); // notice we're trying to connect global foo

sig.emit(0); // program did not crash
assert(listener.i == 1); // Listener.foo was called
```

This happens because of the nature of the implementation. Although `Listener` is discarded, the name  `foo` remains accessible. The implementation checks instance methods primarily, if the check passes then that is the method that is bound.

**Edit**: This issue is now fixed and the example above asserts as it should.